### PR TITLE
Add modeling for base content types & fields

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "trailingComma": "es5",
+  "tabWidth": 2,
+  "semi": false,
+  "singleQuote": true
+}

--- a/src/api/affiliation/content-types/affiliation/schema.json
+++ b/src/api/affiliation/content-types/affiliation/schema.json
@@ -1,0 +1,27 @@
+{
+  "kind": "collectionType",
+  "collectionName": "affiliations",
+  "info": {
+    "singularName": "affiliation",
+    "pluralName": "affiliations",
+    "displayName": "Affiliation",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "Affiliation": {
+      "type": "string",
+      "required": true,
+      "unique": true
+    },
+    "Authors": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::author.author",
+      "mappedBy": "Affiliation"
+    }
+  }
+}

--- a/src/api/affiliation/controllers/affiliation.ts
+++ b/src/api/affiliation/controllers/affiliation.ts
@@ -1,0 +1,7 @@
+/**
+ * affiliation controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::affiliation.affiliation');

--- a/src/api/affiliation/routes/affiliation.ts
+++ b/src/api/affiliation/routes/affiliation.ts
@@ -1,0 +1,7 @@
+/**
+ * affiliation router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::affiliation.affiliation');

--- a/src/api/affiliation/services/affiliation.ts
+++ b/src/api/affiliation/services/affiliation.ts
@@ -1,0 +1,7 @@
+/**
+ * affiliation service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::affiliation.affiliation');

--- a/src/api/author/content-types/author/schema.json
+++ b/src/api/author/content-types/author/schema.json
@@ -1,0 +1,45 @@
+{
+  "kind": "collectionType",
+  "collectionName": "authors",
+  "info": {
+    "singularName": "author",
+    "pluralName": "authors",
+    "displayName": "Author",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "Name": {
+      "type": "string",
+      "required": true
+    },
+    "Email": {
+      "type": "string"
+    },
+    "ORCID": {
+      "type": "string",
+      "required": false
+    },
+    "Affiliation": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::affiliation.affiliation",
+      "inversedBy": "Authors"
+    },
+    "Lectures": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::lecture.lecture",
+      "inversedBy": "Authors"
+    },
+    "Courses": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::course.course",
+      "mappedBy": "Authors"
+    }
+  }
+}

--- a/src/api/author/controllers/author.ts
+++ b/src/api/author/controllers/author.ts
@@ -1,0 +1,7 @@
+/**
+ * author controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::author.author');

--- a/src/api/author/routes/author.ts
+++ b/src/api/author/routes/author.ts
@@ -1,0 +1,7 @@
+/**
+ * author router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::author.author');

--- a/src/api/author/services/author.ts
+++ b/src/api/author/services/author.ts
@@ -1,0 +1,7 @@
+/**
+ * author service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::author.author');

--- a/src/api/block/content-types/block/schema.json
+++ b/src/api/block/content-types/block/schema.json
@@ -1,0 +1,79 @@
+{
+  "kind": "collectionType",
+  "collectionName": "blocks",
+  "info": {
+    "singularName": "block",
+    "pluralName": "blocks",
+    "displayName": "Block",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "Title": {
+      "type": "string",
+      "required": true
+    },
+    "Document": {
+      "type": "richtext"
+    },
+    "Abstract": {
+      "type": "richtext"
+    },
+    "DurationInMinutes": {
+      "type": "integer",
+      "required": true,
+      "min": 0,
+      "default": 0
+    },
+    "Level": {
+      "type": "enumeration",
+      "enum": [
+        "beginner",
+        "intermediate",
+        "expert"
+      ],
+      "required": true
+    },
+    "Media": {
+      "type": "media",
+      "multiple": true,
+      "required": false,
+      "allowedTypes": [
+        "images",
+        "files",
+        "videos",
+        "audios"
+      ]
+    },
+    "Lectures": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::lecture.lecture",
+      "mappedBy": "Blocks"
+    },
+    "Keywords": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::keyword.keyword",
+      "inversedBy": "Blocks"
+    },
+    "Slides": {
+      "type": "component",
+      "repeatable": true,
+      "component": "presentation.slide"
+    },
+    "References": {
+      "type": "component",
+      "repeatable": true,
+      "component": "about-the-material.reference"
+    },
+    "LearningOutcomes": {
+      "type": "component",
+      "repeatable": true,
+      "component": "about-the-material.learning-outcomes"
+    }
+  }
+}

--- a/src/api/block/controllers/block.ts
+++ b/src/api/block/controllers/block.ts
@@ -1,0 +1,7 @@
+/**
+ * block controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::block.block');

--- a/src/api/block/routes/block.ts
+++ b/src/api/block/routes/block.ts
@@ -1,0 +1,7 @@
+/**
+ * block router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::block.block');

--- a/src/api/block/services/block.ts
+++ b/src/api/block/services/block.ts
@@ -1,0 +1,7 @@
+/**
+ * block service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::block.block');

--- a/src/api/course/content-types/course/schema.json
+++ b/src/api/course/content-types/course/schema.json
@@ -1,0 +1,42 @@
+{
+  "kind": "collectionType",
+  "collectionName": "courses",
+  "info": {
+    "singularName": "course",
+    "pluralName": "courses",
+    "displayName": "Course",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "Title": {
+      "pluginOptions": {},
+      "type": "string",
+      "required": true
+    },
+    "Abstract": {
+      "pluginOptions": {},
+      "type": "richtext"
+    },
+    "Authors": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::author.author",
+      "inversedBy": "Courses"
+    },
+    "Lectures": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::lecture.lecture",
+      "inversedBy": "Courses"
+    },
+    "Prerequisites": {
+      "type": "component",
+      "repeatable": true,
+      "component": "about-the-material.prerequisite"
+    }
+  }
+}

--- a/src/api/course/controllers/course.ts
+++ b/src/api/course/controllers/course.ts
@@ -1,0 +1,7 @@
+/**
+ * course controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::course.course');

--- a/src/api/course/routes/course.ts
+++ b/src/api/course/routes/course.ts
@@ -1,0 +1,7 @@
+/**
+ * course router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::course.course');

--- a/src/api/course/services/course.ts
+++ b/src/api/course/services/course.ts
@@ -1,0 +1,7 @@
+/**
+ * course service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::course.course');

--- a/src/api/keyword/content-types/keyword/schema.json
+++ b/src/api/keyword/content-types/keyword/schema.json
@@ -1,0 +1,26 @@
+{
+  "kind": "collectionType",
+  "collectionName": "keywords",
+  "info": {
+    "singularName": "keyword",
+    "pluralName": "keywords",
+    "displayName": "Keyword"
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "Keyword": {
+      "type": "string",
+      "unique": true,
+      "required": true
+    },
+    "Blocks": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::block.block",
+      "mappedBy": "Keywords"
+    }
+  }
+}

--- a/src/api/keyword/controllers/keyword.ts
+++ b/src/api/keyword/controllers/keyword.ts
@@ -1,0 +1,7 @@
+/**
+ * keyword controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::keyword.keyword');

--- a/src/api/keyword/routes/keyword.ts
+++ b/src/api/keyword/routes/keyword.ts
@@ -1,0 +1,7 @@
+/**
+ * keyword router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::keyword.keyword');

--- a/src/api/keyword/services/keyword.ts
+++ b/src/api/keyword/services/keyword.ts
@@ -1,0 +1,7 @@
+/**
+ * keyword service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::keyword.keyword');

--- a/src/api/lecture/content-types/lecture/schema.json
+++ b/src/api/lecture/content-types/lecture/schema.json
@@ -1,0 +1,40 @@
+{
+  "kind": "collectionType",
+  "collectionName": "lectures",
+  "info": {
+    "singularName": "lecture",
+    "pluralName": "lectures",
+    "displayName": "Lecture",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "Title": {
+      "type": "string"
+    },
+    "Blocks": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::block.block",
+      "inversedBy": "Lectures"
+    },
+    "Abstract": {
+      "type": "richtext"
+    },
+    "Authors": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::author.author",
+      "mappedBy": "Lectures"
+    },
+    "Courses": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::course.course",
+      "mappedBy": "Lectures"
+    }
+  }
+}

--- a/src/api/lecture/controllers/lecture.ts
+++ b/src/api/lecture/controllers/lecture.ts
@@ -1,0 +1,7 @@
+/**
+ * lecture controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::lecture.lecture');

--- a/src/api/lecture/routes/lecture.ts
+++ b/src/api/lecture/routes/lecture.ts
@@ -1,0 +1,7 @@
+/**
+ * lecture router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::lecture.lecture');

--- a/src/api/lecture/services/lecture.ts
+++ b/src/api/lecture/services/lecture.ts
@@ -1,0 +1,7 @@
+/**
+ * lecture service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::lecture.lecture');

--- a/src/components/about-the-material/learning-outcomes.json
+++ b/src/components/about-the-material/learning-outcomes.json
@@ -1,0 +1,15 @@
+{
+  "collectionName": "components_about_the_material_learning_outcomes",
+  "info": {
+    "displayName": "Learning outcome",
+    "icon": "brain",
+    "description": ""
+  },
+  "options": {},
+  "attributes": {
+    "LearningOutcome": {
+      "type": "string",
+      "required": true
+    }
+  }
+}

--- a/src/components/about-the-material/prerequisite.json
+++ b/src/components/about-the-material/prerequisite.json
@@ -1,0 +1,14 @@
+{
+  "collectionName": "components_about_the_material_prerequisites",
+  "info": {
+    "displayName": "Prerequisite",
+    "icon": "list-ol"
+  },
+  "options": {},
+  "attributes": {
+    "Prerequisite": {
+      "type": "string",
+      "required": true
+    }
+  }
+}

--- a/src/components/about-the-material/reference.json
+++ b/src/components/about-the-material/reference.json
@@ -1,0 +1,18 @@
+{
+  "collectionName": "components_acknowledgement_references",
+  "info": {
+    "displayName": "Reference",
+    "icon": "hands-helping",
+    "description": ""
+  },
+  "options": {},
+  "attributes": {
+    "Name": {
+      "type": "string",
+      "required": true
+    },
+    "ORCID": {
+      "type": "string"
+    }
+  }
+}

--- a/src/components/presentation/slide.json
+++ b/src/components/presentation/slide.json
@@ -1,0 +1,22 @@
+{
+  "collectionName": "components_presentation_slides",
+  "info": {
+    "displayName": "Slide",
+    "icon": "chalkboard-teacher",
+    "description": ""
+  },
+  "options": {},
+  "attributes": {
+    "Title": {
+      "type": "string",
+      "required": false
+    },
+    "Content": {
+      "type": "richtext",
+      "required": true
+    },
+    "SpeakerNotes": {
+      "type": "richtext"
+    }
+  }
+}


### PR DESCRIPTION
Adds the models as we view them as of right now. Make sure to pull the branch and try it out locally, since it's obviously much easier to grasp the relations from the UI than reading these schemas.