### PR TITLE
Add controllers to find block+lecture+course on vuid (instead of id)

### DIFF
--- a/src/api/block/controllers/block.ts
+++ b/src/api/block/controllers/block.ts
@@ -4,4 +4,52 @@
 
 import { factories } from '@strapi/strapi'
 
-export default factories.createCoreController('api::block.block');
+type Block = {
+  id: number
+  vuid: string
+  isVisibleInListView: boolean
+  publishedAt: null | string
+}
+
+export default factories.createCoreController(
+  'api::block.block',
+  ({ strapi }) => ({
+    async findByVuid(ctx) {
+      try {
+        const { vuid } = ctx.params
+        const { populate } = ctx.query
+
+        const entries: Block[] = await strapi.entityService.findMany(
+          'api::block.block',
+          {
+            filters: {
+              vuid,
+            },
+            populate,
+          }
+        )
+
+        if (entries === undefined || entries.length === 0) {
+          ctx.status = 404
+          ctx.body = `Unable to find block with vuid ${vuid}`
+          return
+        }
+
+        const entry = entries.find(
+          (entry) => entry.isVisibleInListView && entry.publishedAt !== null
+        )
+
+        if (entry === undefined) {
+          ctx.body = 404
+          ctx.body = `Unable to find a published block with vuid ${vuid}`
+        }
+
+        const sanitizedEntry = await this.sanitizeOutput(entry, ctx)
+        ctx.body = sanitizedEntry
+      } catch (error) {
+        ctx.status = 500
+        ctx.body = error
+      }
+    },
+  })
+)

--- a/src/api/block/routes/block.ts
+++ b/src/api/block/routes/block.ts
@@ -2,6 +2,6 @@
  * block router
  */
 
-import { factories } from '@strapi/strapi';
+import { factories } from '@strapi/strapi'
 
-export default factories.createCoreRouter('api::block.block');
+export default factories.createCoreRouter('api::block.block')

--- a/src/api/block/routes/blockByVuid.ts
+++ b/src/api/block/routes/blockByVuid.ts
@@ -1,0 +1,9 @@
+module.exports = {
+  routes: [
+    {
+      method: 'GET',
+      path: '/blockByVuid/:vuid',
+      handler: 'block.findByVuid',
+    },
+  ],
+}

--- a/src/api/course/controllers/course.ts
+++ b/src/api/course/controllers/course.ts
@@ -4,4 +4,52 @@
 
 import { factories } from '@strapi/strapi'
 
-export default factories.createCoreController('api::course.course');
+type Course = {
+  id: number
+  vuid: string
+  isVisibleInListView: boolean
+  publishedAt: null | string
+}
+
+export default factories.createCoreController(
+  'api::course.course',
+  ({ strapi }) => ({
+    async findByVuid(ctx) {
+      try {
+        const { vuid } = ctx.params
+        const { populate } = ctx.query
+
+        const entries: Course[] = await strapi.entityService.findMany(
+          'api::course.course',
+          {
+            filters: {
+              vuid,
+            },
+            populate,
+          }
+        )
+
+        if (entries === undefined || entries.length === 0) {
+          ctx.status = 404
+          ctx.body = `Unable to find course with vuid ${vuid}`
+          return
+        }
+
+        const entry = entries.find(
+          (entry) => entry.isVisibleInListView && entry.publishedAt !== null
+        )
+
+        if (entry === undefined) {
+          ctx.body = 404
+          ctx.body = `Unable to find a published course with vuid ${vuid}`
+        }
+
+        const sanitizedEntry = await this.sanitizeOutput(entry, ctx)
+        ctx.body = sanitizedEntry
+      } catch (error) {
+        ctx.status = 500
+        ctx.body = error
+      }
+    },
+  })
+)

--- a/src/api/course/routes/courseByVuid.ts
+++ b/src/api/course/routes/courseByVuid.ts
@@ -1,0 +1,9 @@
+module.exports = {
+  routes: [
+    {
+      method: 'GET',
+      path: '/courseByVuid/:vuid',
+      handler: 'course.findByVuid',
+    },
+  ],
+}

--- a/src/api/lecture/controllers/lecture.ts
+++ b/src/api/lecture/controllers/lecture.ts
@@ -4,4 +4,52 @@
 
 import { factories } from '@strapi/strapi'
 
-export default factories.createCoreController('api::lecture.lecture');
+type Lecture = {
+  id: number
+  vuid: string
+  isVisibleInListView: boolean
+  publishedAt: null | string
+}
+
+export default factories.createCoreController(
+  'api::lecture.lecture',
+  ({ strapi }) => ({
+    async findByVuid(ctx) {
+      try {
+        const { vuid } = ctx.params
+        const { populate } = ctx.query
+
+        const entries: Lecture[] = await strapi.entityService.findMany(
+          'api::lecture.lecture',
+          {
+            filters: {
+              vuid,
+            },
+            populate,
+          }
+        )
+
+        if (entries === undefined || entries.length === 0) {
+          ctx.status = 404
+          ctx.body = `Unable to find lecture with vuid ${vuid}`
+          return
+        }
+
+        const entry = entries.find(
+          (entry) => entry.isVisibleInListView && entry.publishedAt !== null
+        )
+
+        if (entry === undefined) {
+          ctx.body = 404
+          ctx.body = `Unable to find a published lecture with vuid ${vuid}`
+        }
+
+        const sanitizedEntry = await this.sanitizeOutput(entry, ctx)
+        ctx.body = sanitizedEntry
+      } catch (error) {
+        ctx.status = 500
+        ctx.body = error
+      }
+    },
+  })
+)

--- a/src/api/lecture/routes/lectureByVuid.ts
+++ b/src/api/lecture/routes/lectureByVuid.ts
@@ -1,0 +1,9 @@
+module.exports = {
+  routes: [
+    {
+      method: 'GET',
+      path: '/lectureByVuid/:vuid',
+      handler: 'lecture.findByVuid',
+    },
+  ],
+}


### PR DESCRIPTION
Should be merged before: https://github.com/ClimateCompatibleGrowth/teaching-kit-frontend/pull/96

Will look for a way to wrap the response in the same data/attributes-structure as the default Strapi endpoints.