### PR TITLE
Separate given and family names of authors

### DIFF
--- a/src/api/author/content-types/author/schema.json
+++ b/src/api/author/content-types/author/schema.json
@@ -12,7 +12,11 @@
   },
   "pluginOptions": {},
   "attributes": {
-    "Name": {
+    "FirstName": {
+      "type": "string",
+      "required": true
+    },
+    "LastName": {
       "type": "string",
       "required": true
     },


### PR DESCRIPTION
Zenodo requires the names in a special format. This change is however not solely made because of Zenodo, rather it makes more sense to keep the two name types separate.