### PR TITLE
Add fallback locale fetch, in case requested locale does not exist

### DIFF
--- a/src/api/course/controllers/course.ts
+++ b/src/api/course/controllers/course.ts
@@ -17,22 +17,34 @@ export default factories.createCoreController(
     async findByVuid(ctx) {
       try {
         const { vuid } = ctx.params
-        const { populate } = ctx.query
+        const {
+          populate,
+          locale,
+          fallbackToDefaultLocale = 'false',
+        } = ctx.query
 
-        const entries: Course[] = await strapi.entityService.findMany(
+        let entries: Course[] = await strapi.entityService.findMany(
           'api::course.course',
           {
             filters: {
               vuid,
             },
+            locale: locale ?? 'en',
             populate,
           }
         )
 
-        if (entries === undefined || entries.length === 0) {
-          ctx.status = 404
-          ctx.body = `Unable to find course with vuid ${vuid}`
-          return
+        if (
+          fallbackToDefaultLocale === 'true' &&
+          (entries === undefined || entries.length === 0)
+        ) {
+          entries = await strapi.entityService.findMany('api::course.course', {
+            filters: {
+              vuid,
+            },
+            locale: 'en',
+            populate,
+          })
         }
 
         const entry = entries.find(
@@ -40,8 +52,7 @@ export default factories.createCoreController(
         )
 
         if (entry === undefined) {
-          ctx.body = 404
-          ctx.body = `Unable to find a published course with vuid ${vuid}`
+          return notFound(ctx, vuid)
         }
 
         const sanitizedEntry = await this.sanitizeOutput(entry, ctx)
@@ -53,3 +64,8 @@ export default factories.createCoreController(
     },
   })
 )
+
+const notFound = (ctx, vuid: string) => {
+  ctx.status = 404
+  ctx.body = `Unable to find block with vuid ${vuid}`
+}


### PR DESCRIPTION
The fallback is necessary in cases where the translated version is not available. In those cases we want to show the english (default) version instead of a 404 page.
(It's weird, because I can swear this kind of fallback happened automatically before, but I can't get it to work now, and not find anything online on it either.

Frontend counter-part: https://github.com/ClimateCompatibleGrowth/teaching-kit-frontend/pull/105